### PR TITLE
Fix material indexing

### DIFF
--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
@@ -77,7 +77,7 @@ jobs:
           find .
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           

--- a/converter/shieldhit/geo.py
+++ b/converter/shieldhit/geo.py
@@ -258,7 +258,7 @@ END
         """Generate mat.dat config."""
         # we increment idx because shieldhit indexes from 1 while python indexes lists from 0
         material_strings = [
-            self.material_template.format(idx=idx + 1, mat=mat_value)
-            for idx, [_, mat_value] in enumerate([material for material in self.materials if not DefaultMaterial.is_default_material(material[1])])
+            self.material_template.format(idx=idx + 1, mat=mat_value) for idx, [_, mat_value] in enumerate(
+                filter(lambda x: not DefaultMaterial.is_default_material(x[1]), self.materials))
         ]
         return "".join(material_strings)

--- a/converter/shieldhit/geo.py
+++ b/converter/shieldhit/geo.py
@@ -259,6 +259,6 @@ END
         # we increment idx because shieldhit indexes from 1 while python indexes lists from 0
         material_strings = [
             self.material_template.format(idx=idx + 1, mat=mat_value)
-            for idx, [_, mat_value] in enumerate(self.materials) if not DefaultMaterial.is_default_material(mat_value)
+            for idx, [_, mat_value] in enumerate([material for material in self.materials if not DefaultMaterial.is_default_material(material[1])])
         ]
         return "".join(material_strings)

--- a/converter/shieldhit/parser.py
+++ b/converter/shieldhit/parser.py
@@ -233,15 +233,21 @@ class ShieldhitParser(DummmyParser):
 
     def _get_material_id(self, uuid: str) -> int:
         """Find material by uuid and retun its id."""
+        offset = 0
         for idx, [mat_uuid, mat_value] in enumerate(self.geo_mat_config.materials):
-            if mat_uuid == uuid:
-                # If the material is a DefaultMaterial then we need the value not its index,
-                # the _value2member_map_ returns a map of values and members that allows us to check if
-                # a given value is defined within the DefaultMaterial enum.
-                if DefaultMaterial.is_default_material(mat_value):
+            # If the material is a DefaultMaterial then we need the value not its index,
+            # the _value2member_map_ returns a map of values and members that allows us to check if
+            # a given value is defined within the DefaultMaterial enum.
+            if DefaultMaterial.is_default_material(mat_value):
+                if mat_uuid == uuid:
                     return int(mat_value)
-
-                return idx + 1
+                else:
+                    # We need to count all DefaultMaterials prior to the searched one.
+                    offset += 1
+            else:
+                if mat_uuid == uuid:
+                    # Only materials defined in mat.dat file are indexed.
+                    return idx + 1 - offset
 
         raise ValueError(f"No material with uuid {uuid} in materials {self.geo_mat_config.materials}.")
 

--- a/converter/shieldhit/parser.py
+++ b/converter/shieldhit/parser.py
@@ -26,6 +26,8 @@ class DummmyParser(Parser):
         Save the configs as text files in the target_dir.
         The files are: beam.dat, mat.dat, detect.dat and geo.dat.
         """
+        if not path.exists(target_dir):
+            raise ValueError("Target directory does not exist.")
         target_dir = path.abspath(target_dir)
 
         for file_name, content in self.get_configs_json().items():
@@ -216,9 +218,8 @@ class ShieldhitParser(DummmyParser):
 
     def _parse_title(self, json: dict) -> None:
         """Parses data from the input json into the geo_mat_config property"""
-        title = json["project"]["title"]
-        if (title != ""):
-            self.geo_mat_config.title = title
+        if "title" in json["project"] and json["project"]["title"].length > 0:
+            self.geo_mat_config.title = json["project"]["title"]
 
     def _parse_materials(self, json: dict) -> None:
         """Parse materials from JSON"""
@@ -280,7 +281,7 @@ class ShieldhitParser(DummmyParser):
                     # the material of the world zone is usually defined as vacuum
                     material=material))
 
-        if (material != DefaultMaterial.BLACK_HOLE.value):
+        if material != DefaultMaterial.BLACK_HOLE.value:
             # Add the figure that will serve as a black hole wrapper around the world zone
             black_hole_figure = solid_figures.parse_figure(world_zone)
 

--- a/converter/shieldhit/parser.py
+++ b/converter/shieldhit/parser.py
@@ -1,4 +1,5 @@
 import itertools
+from pathlib import Path
 from os import path
 from converter.shieldhit.geo import DefaultMaterial
 from converter.common import Parser
@@ -26,12 +27,11 @@ class DummmyParser(Parser):
         Save the configs as text files in the target_dir.
         The files are: beam.dat, mat.dat, detect.dat and geo.dat.
         """
-        if not path.exists(target_dir):
+        if not Path(target_dir).exists():
             raise ValueError("Target directory does not exist.")
-        target_dir = path.abspath(target_dir)
 
         for file_name, content in self.get_configs_json().items():
-            with open(path.join(target_dir, file_name), 'w') as conf_f:
+            with open(Path(target_dir, file_name), 'w') as conf_f:
                 conf_f.write(content)
 
     def get_configs_json(self) -> dict:
@@ -218,7 +218,7 @@ class ShieldhitParser(DummmyParser):
 
     def _parse_title(self, json: dict) -> None:
         """Parses data from the input json into the geo_mat_config property"""
-        if "title" in json["project"] and json["project"]["title"].length > 0:
+        if "title" in json["project"] and len(json["project"]["title"]) > 0:
             self.geo_mat_config.title = json["project"]["title"]
 
     def _parse_materials(self, json: dict) -> None:
@@ -281,7 +281,10 @@ class ShieldhitParser(DummmyParser):
                     # the material of the world zone is usually defined as vacuum
                     material=material))
 
+        # Adding Black Hole wrapper outside of the World Zone is redundant
+        # if the World Zone already is made of Black Hole
         if material != DefaultMaterial.BLACK_HOLE.value:
+
             # Add the figure that will serve as a black hole wrapper around the world zone
             black_hole_figure = solid_figures.parse_figure(world_zone)
 

--- a/converter/solid_figures.py
+++ b/converter/solid_figures.py
@@ -51,7 +51,7 @@ class CylinderFigure(SolidFigure):
         """
         self.radius_top += margin
         self.radius_bottom += margin
-        self.height += margin*2
+        self.height += margin * 2
 
 
 @dataclass(frozen=False)
@@ -59,7 +59,7 @@ class BoxFigure(SolidFigure):
     """
     A rectangular box (cuboid). The figure can be rotated (meaning its walls don't have
     to be aligned with the axes of the coordinate system). The edge lengths are the final lengths of
-    each edge, not the distance from the center of the figure (meaning they are full-size not half-size,
+    each edge, not the distance from the center of the figure (meaning they are full-size not hageometryDatalf-size,
     for example: the edge lengths 1, 1, 1 will result in a 1 by 1 by 1 cube).
     """
 
@@ -73,37 +73,39 @@ class BoxFigure(SolidFigure):
         Increases figures weight, depth and height by 2 * `margin` to achieve the same
         expansion (1 * `margin`) on each side.
         """
-        self.x_edge_length += margin*2
-        self.y_edge_length += margin*2
-        self.z_edge_length += margin*2
+        self.x_edge_length += margin * 2
+        self.y_edge_length += margin * 2
+        self.z_edge_length += margin * 2
 
 
 def parse_figure(figure_dict: dict) -> SolidFigure:
     """Parse json containing information about figure to figure."""
-    figure_type = figure_dict["userData"]["geometryType"]
+    figure_type = figure_dict["geometryData"]["geometryType"]
     if figure_type == "CylinderGeometry":
-        return CylinderFigure(uuid=figure_dict["uuid"],
-                              position=tuple(figure_dict["userData"]["position"]),
-                              rotation=tuple(figure_dict["userData"]["rotation"]),
-                              radius_top=figure_dict["userData"]['parameters']["radiusTop"],
-                              radius_bottom=figure_dict["userData"]['parameters']["radiusBottom"]
-                              if "radiusBottom" in figure_dict["userData"]['parameters'] else 0,
-                              height=figure_dict["userData"]['parameters']["height"],
-                              )
+        return CylinderFigure(
+            uuid=figure_dict["uuid"],
+            position=tuple(figure_dict["geometryData"]["position"]),
+            rotation=tuple(figure_dict["geometryData"]["rotation"]),
+            radius_top=figure_dict["geometryData"]['parameters']["radius"],
+            radius_bottom=figure_dict["geometryData"]['parameters']["radius"],
+            height=figure_dict["geometryData"]['parameters']["depth"],
+        )
     if figure_type == "BoxGeometry":
-        return BoxFigure(uuid=figure_dict["uuid"],
-                         position=tuple(figure_dict["userData"]["position"]),
-                         rotation=tuple(figure_dict["userData"]["rotation"]),
-                         y_edge_length=figure_dict["userData"]['parameters']["height"],
-                         x_edge_length=figure_dict["userData"]['parameters']["width"],
-                         z_edge_length=figure_dict["userData"]['parameters']["depth"],
-                         )
+        return BoxFigure(
+            uuid=figure_dict["uuid"],
+            position=tuple(figure_dict["geometryData"]["position"]),
+            rotation=tuple(figure_dict["geometryData"]["rotation"]),
+            y_edge_length=figure_dict["geometryData"]['parameters']["height"],
+            x_edge_length=figure_dict["geometryData"]['parameters']["width"],
+            z_edge_length=figure_dict["geometryData"]['parameters']["depth"],
+        )
     if figure_type == "SphereGeometry":
-        return SphereFigure(uuid=figure_dict["uuid"],
-                            position=tuple(figure_dict["userData"]["position"]),
-                            rotation=tuple(figure_dict["userData"]["rotation"]),
-                            radius=figure_dict["userData"]['parameters']["radius"],
-                            )
+        return SphereFigure(
+            uuid=figure_dict["uuid"],
+            position=tuple(figure_dict["geometryData"]["position"]),
+            rotation=tuple(figure_dict["geometryData"]["rotation"]),
+            radius=figure_dict["geometryData"]['parameters']["radius"],
+        )
 
     print(f"Invalid figure type \"{figure_type}\".")
     raise ValueError("Parser type must be either 'CylinderGeometry', 'BoxGeometry' or 'SphereGeometry'")

--- a/input_examples/sh_parser_test.json
+++ b/input_examples/sh_parser_test.json
@@ -22,24 +22,7 @@
             "type": "PerspectiveCamera",
             "name": "Camera",
             "layers": 1,
-            "matrix": [
-                1,
-                0,
-                0,
-                0,
-                0,
-                1,
-                0,
-                0,
-                0,
-                0,
-                1,
-                0,
-                0,
-                5,
-                10,
-                1
-            ],
+            "matrix": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 5, 10, 1],
             "fov": 50,
             "zoom": 1,
             "near": 0.01,
@@ -155,45 +138,20 @@
             "type": "Scene",
             "name": "Figures",
             "layers": 1,
-            "matrix": [
-                1,
-                0,
-                0,
-                0,
-                0,
-                1,
-                0,
-                0,
-                0,
-                0,
-                1,
-                0,
-                0,
-                0,
-                0,
-                1
-            ],
+            "matrix": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
             "children": [
                 {
                     "uuid": "48EE4307-80C7-47AA-BF01-9132898B2B5A",
                     "type": "BoxMesh",
                     "name": "Box",
-                    "userData": {
+                    "geometryData": {
                         "id": 860,
                         "geometryType": "CylinderGeometry",
-                        "position": [
-                            0,
-                            0,
-                            10
-                        ],
-                        "rotation": [
-                            90,
-                            0,
-                            0
-                        ],
+                        "position": [0, 0, 10],
+                        "rotation": [90, 0, 0],
                         "parameters": {
-                            "radiusTop": 10,
-                            "height": 20
+                            "radius": 10,
+                            "depth": 20
                         }
                     },
                     "layers": 1,
@@ -254,23 +212,15 @@
             "marginMultiplier": 1.1,
             "autoCalculate": false,
             "materialUuid": "37C3F777-8B67-46B2-9D7F-374B49330F5C",
-            "userData": {
+            "geometryData": {
                 "geometryType": "BoxGeometry",
                 "parameters": {
                     "width": 22,
                     "height": 22,
                     "depth": 22
                 },
-                "position": [
-                    0,
-                    0,
-                    0
-                ],
-                "rotation": [
-                    0,
-                    0,
-                    0
-                ]
+                "position": [0, 0, 0],
+                "rotation": [0, 0, 0]
             }
         }
     },
@@ -288,11 +238,7 @@
                     "zSegments": 400
                 },
                 "type": "Cyl",
-                "position": [
-                    0,
-                    0,
-                    10
-                ],
+                "position": [0, 0, 10],
                 "name": "CylZ_Mesh",
                 "colorHex": 65535
             },
@@ -307,11 +253,7 @@
                     "zSegments": 400
                 },
                 "type": "Mesh",
-                "position": [
-                    0,
-                    0,
-                    10
-                ],
+                "position": [0, 0, 10],
                 "name": "YZ_Mesh",
                 "colorHex": 65535
             }
@@ -319,16 +261,8 @@
         "filters": []
     },
     "beam": {
-        "position": [
-            0,
-            0,
-            0
-        ],
-        "direction": [
-            0,
-            0,
-            1
-        ],
+        "position": [0, 0, 0],
+        "direction": [0, 0, 1],
         "energy": 150,
         "energySpread": 1.5,
         "divergence": {

--- a/tests/test_solid_figures.py
+++ b/tests/test_solid_figures.py
@@ -1,48 +1,46 @@
 import pytest
 from converter import solid_figures
 
-
 _Json_with_figures = {
     "object": {
         "children": [
             {
                 "uuid": "3A594908-17F2-4858-A16E-EE20BD387C26",
-                "userData": {
-                        "id": 940,
-                        "geometryType": "CylinderGeometry",
-                        "position": [1, 2, 3],
-                        "rotation": [45, 60, 90],
-                        "parameters": {
-                            "radiusTop": 1,
-                            "radiusBottom": 1,
-                            "height": 1
-                        }
+                "geometryData": {
+                    "id": 940,
+                    "geometryType": "CylinderGeometry",
+                    "position": [1, 2, 3],
+                    "rotation": [45, 60, 90],
+                    "parameters": {
+                        "radius": 1,
+                        "depth": 1
+                    }
                 },
             },
             {
                 "uuid": "CBE326F9-48BB-4E5D-83CC-4F85B057AE00",
-                "userData": {
-                        "id": 941,
-                        "geometryType": "BoxGeometry",
-                        "position": [1, 2, 3],
-                        "rotation": [45, 60, 90],
-                        "parameters": {
-                            "width": 1,
-                            "height": 1,
-                            "depth": 1
-                        }
+                "geometryData": {
+                    "id": 941,
+                    "geometryType": "BoxGeometry",
+                    "position": [1, 2, 3],
+                    "rotation": [45, 60, 90],
+                    "parameters": {
+                        "width": 1,
+                        "height": 1,
+                        "depth": 1
+                    }
                 },
             },
             {
                 "uuid": "B0568AB3-A8F8-4615-8FF1-6121B506456F",
-                "userData": {
-                        "id": 1113,
-                        "geometryType": "SphereGeometry",
-                        "position": [1, 2, 3],
-                        "rotation": [45, 60, 90],
-                        "parameters": {
-                            "radius": 1
-                        }
+                "geometryData": {
+                    "id": 1113,
+                    "geometryType": "SphereGeometry",
+                    "position": [1, 2, 3],
+                    "rotation": [45, 60, 90],
+                    "parameters": {
+                        "radius": 1
+                    }
                 },
             },
         ]
@@ -60,41 +58,34 @@ def figure(request):
     return solid_figures.parse_figure(request.param)
 
 
-@pytest.mark.parametrize("figure,expected", [
-    (_Cylinder_json, solid_figures.CylinderFigure),
-    (_Box_json, solid_figures.BoxFigure),
-    (_Sphere_json, solid_figures.SphereFigure)
-], indirect=["figure"])
+@pytest.mark.parametrize("figure,expected", [(_Cylinder_json, solid_figures.CylinderFigure),
+                                             (_Box_json, solid_figures.BoxFigure),
+                                             (_Sphere_json, solid_figures.SphereFigure)],
+                         indirect=["figure"])
 def test_type(figure, expected):
     """Test if parser returns correct figure object type"""
     assert type(figure) is expected
 
 
-@pytest.mark.parametrize("figure,expected", [
-    (_Cylinder_json, _Cylinder_json),
-    (_Box_json, _Box_json),
-    (_Sphere_json, _Sphere_json)
-], indirect=["figure"])
+@pytest.mark.parametrize("figure,expected", [(_Cylinder_json, _Cylinder_json), (_Box_json, _Box_json),
+                                             (_Sphere_json, _Sphere_json)],
+                         indirect=["figure"])
 def test_uuid(figure, expected):
     """Test if figure_parser parses uuid correctly"""
     assert figure.uuid == expected['uuid']
 
 
-@pytest.mark.parametrize("figure,expected", [
-    (_Cylinder_json, _Cylinder_json),
-    (_Box_json, _Box_json),
-    (_Sphere_json, _Sphere_json)
-], indirect=["figure"])
+@pytest.mark.parametrize("figure,expected", [(_Cylinder_json, _Cylinder_json), (_Box_json, _Box_json),
+                                             (_Sphere_json, _Sphere_json)],
+                         indirect=["figure"])
 def test_position(figure, expected):
     """Test if figure_parser parses position(position) correctly"""
-    assert figure.position == tuple(expected['userData']['position'])
+    assert figure.position == tuple(expected['geometryData']['position'])
 
 
-@pytest.mark.parametrize("figure,expected", [
-    (_Cylinder_json, _Cylinder_json),
-    (_Box_json, _Box_json),
-    (_Sphere_json, _Sphere_json)
-], indirect=["figure"])
+@pytest.mark.parametrize("figure,expected", [(_Cylinder_json, _Cylinder_json), (_Box_json, _Box_json),
+                                             (_Sphere_json, _Sphere_json)],
+                         indirect=["figure"])
 def test_rotation(figure, expected):
     """Test if figure_parser parses rotation correctly"""
-    assert figure.rotation == tuple(expected['userData']['rotation'])
+    assert figure.rotation == tuple(expected['geometryData']['rotation'])

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -5,7 +5,7 @@ from converter import solid_figures
 _Box_test_cases = [
     ({
         "uuid": "CBE326F9-48BB-4E5D-83CC-4F85B057AE00",
-                "userData": {
+                "geometryData": {
                     "id": 941,
                     "geometryType": "BoxGeometry",
                     "position": [1, 2, 3],
@@ -24,15 +24,14 @@ _Box_test_cases = [
 _Cylinder_test_cases = [
     ({
         "uuid": "3A594908-17F2-4858-A16E-EE20BD387C26",
-                "userData": {
+                "geometryData": {
                     "id": 940,
                     "geometryType": "CylinderGeometry",
                     "position": [1, 2, 3],
                     "rotation": [0, 0, 0],
                     "parameters": {
-                        "radiusTop": 1,
-                        "radiusBottom": 1,
-                        "height": 1
+                        "radius": 1,
+                        "depth": 1
                     }
                 },
     }, """
@@ -43,7 +42,7 @@ _Cylinder_test_cases = [
 _Sphere_test_cases = [
     ({
         "uuid": "B0568AB3-A8F8-4615-8FF1-6121B506456F",
-                "userData": {
+                "geometryData": {
                     "id": 1113,
                     "geometryType": "SphereGeometry",
                     "position": [1, 2, 3],


### PR DESCRIPTION
Old indexing counted Black-hole and Vaccuum as valid Materials to define in mat.dat
![image](https://user-images.githubusercontent.com/26445545/175781132-dcf1a611-0f56-446e-90f7-a8c60854d6b1.png)
The new function ignores them
![image](https://user-images.githubusercontent.com/26445545/175781162-a69c7d83-5f56-4bf7-96bb-7a38294cdb65.png)
