### PR TITLE
Fix material indexing

### DIFF
--- a/converter/shieldhit/parser.py
+++ b/converter/shieldhit/parser.py
@@ -233,15 +233,21 @@ class ShieldhitParser(DummmyParser):
 
     def _get_material_id(self, uuid: str) -> int:
         """Find material by uuid and retun its id."""
+        offset = 0
         for idx, [mat_uuid, mat_value] in enumerate(self.geo_mat_config.materials):
-            if mat_uuid == uuid:
-                # If the material is a DefaultMaterial then we need the value not its index,
-                # the _value2member_map_ returns a map of values and members that allows us to check if
-                # a given value is defined within the DefaultMaterial enum.
-                if DefaultMaterial.is_default_material(mat_value):
+            # If the material is a DefaultMaterial then we need the value not its index,
+            # the _value2member_map_ returns a map of values and members that allows us to check if
+            # a given value is defined within the DefaultMaterial enum.
+            if DefaultMaterial.is_default_material(mat_value):
+                if mat_uuid == uuid:
                     return int(mat_value)
-
-                return idx + 1
+                else:
+                    # We need to count all DefaultMaterials prior to the searched one.
+                    offset += 1
+            else:
+                if mat_uuid == uuid:
+                    # Only materials defined in mat.dat file are indexed.
+                    return idx + 1 - offset
 
         raise ValueError(f"No material with uuid {uuid} in materials {self.geo_mat_config.materials}.")
 

--- a/converter/shieldhit/parser.py
+++ b/converter/shieldhit/parser.py
@@ -235,21 +235,21 @@ class ShieldhitParser(DummmyParser):
         """Find material by uuid and retun its id."""
         offset = 0
         for idx, [mat_uuid, mat_value] in enumerate(self.geo_mat_config.materials):
-            
+
             # If the material is a DefaultMaterial then we need the value not its index,
             # the _value2member_map_ returns a map of values and members that allows us to check if
             # a given value is defined within the DefaultMaterial enum.
             if DefaultMaterial.is_default_material(mat_value):
-                
+
                 if mat_uuid == uuid:
                     return int(mat_value)
 
                 # We need to count all DefaultMaterials prior to the searched one.
                 offset += 1
-            
+
             elif mat_uuid == uuid:
-                    # Only materials defined in mat.dat file are indexed.
-                    return idx + 1 - offset
+                # Only materials defined in mat.dat file are indexed.
+                return idx + 1 - offset
 
         raise ValueError(f"No material with uuid {uuid} in materials {self.geo_mat_config.materials}.")
 

--- a/converter/shieldhit/parser.py
+++ b/converter/shieldhit/parser.py
@@ -235,17 +235,19 @@ class ShieldhitParser(DummmyParser):
         """Find material by uuid and retun its id."""
         offset = 0
         for idx, [mat_uuid, mat_value] in enumerate(self.geo_mat_config.materials):
+            
             # If the material is a DefaultMaterial then we need the value not its index,
             # the _value2member_map_ returns a map of values and members that allows us to check if
             # a given value is defined within the DefaultMaterial enum.
             if DefaultMaterial.is_default_material(mat_value):
+                
                 if mat_uuid == uuid:
                     return int(mat_value)
-                else:
-                    # We need to count all DefaultMaterials prior to the searched one.
-                    offset += 1
-            else:
-                if mat_uuid == uuid:
+
+                # We need to count all DefaultMaterials prior to the searched one.
+                offset += 1
+            
+            elif mat_uuid == uuid:
                     # Only materials defined in mat.dat file are indexed.
                     return idx + 1 - offset
 


### PR DESCRIPTION
Old indexing counted Black-hole and Vaccuum as valid Materials to define in mat.dat
![image](https://user-images.githubusercontent.com/26445545/175781132-dcf1a611-0f56-446e-90f7-a8c60854d6b1.png)
The new function ignores them
![image](https://user-images.githubusercontent.com/26445545/175781162-a69c7d83-5f56-4bf7-96bb-7a38294cdb65.png)
