### PR TITLE
Fixed the calculation of the starting position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,5 +266,6 @@ cython_debug/
 # End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,pycharm
 
 **/*.dat
+**/info*.json
 !tests/shieldhit/resources/expected_shieldhit_output/*.dat
 .vscode/settings.json

--- a/converter/shieldhit/geo.py
+++ b/converter/shieldhit/geo.py
@@ -38,7 +38,9 @@ def _parse_box(box: BoxFigure, number: int) -> str:
     x_vec = rotate([box.x_edge_length, 0, 0], box.rotation)
     y_vec = rotate([0, box.y_edge_length, 0], box.rotation)
     z_vec = rotate([0, 0, box.z_edge_length], box.rotation)
-    diagonal_vec = x_vec + y_vec + z_vec
+    diagonal_vec = [x_vec[0] + y_vec[0] + z_vec[0],
+                    x_vec[1] + y_vec[1] + z_vec[1],
+                    x_vec[2] + y_vec[2] + z_vec[2],]
     start_position = (
         box.position[0] - diagonal_vec[0] / 2,
         box.position[1] - diagonal_vec[1] / 2,


### PR DESCRIPTION
This pull request includes a small but important change to the `converter/shieldhit/geo.py` file. The change modifies the calculation of the `diagonal_vec` in the `_parse_box` function to explicitly sum the corresponding components of the `x_vec`, `y_vec`, and `z_vec` vectors, instead of summing the vectors directly.

* [`converter/shieldhit/geo.py`](diffhunk://#diff-bfe9262d64847717b2e23750ca9a18888bde34adf14f9feb89d77a7d414dc414L41-R43): Modified the calculation of `diagonal_vec` to explicitly sum the components of `x_vec`, `y_vec`, and `z_vec` vectors.