### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |
@@ -38,12 +38,14 @@ jobs:
     needs: smoke-test-on-linux
     strategy:
       matrix:
+        platform: ['windows-latest', 'macos-latest', 'ubuntu-latest']
         python-version: ['3.11']
-        platform: ['windows-latest', 'macos-latest']
         include:
           - python-version: '3.9'
             platform: 'ubuntu-latest'
           - python-version: '3.10'
+            platform: 'ubuntu-latest'
+          - python-version: '3.12'
             platform: 'ubuntu-latest'
 
     steps:
@@ -98,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
        matrix:
-         python-version: ['3.9', '3.10', '3.11']
+         python-version: ['3.9', '3.10', '3.11', '3.12']
     needs: make-package
     steps:
       - name: Fetch package as artifacts


### PR DESCRIPTION
Fixes #200

Add support for Python 3.12 in GitHub Actions workflow.

* Update the `python-version` in the `smoke-test-on-linux` job to '3.12'.
* Simplify the matrix in the `build-and-test` job to have only one python version (3.11) for mac, windows, and Linux, and three different versions (3.9, 3.10, 3.12) for Linux.
* Add '3.11' for windows/macosx/linux matrix item in the `build-and-test` job.
* Update the `python-version` matrix in the `test-package` job to include '3.12'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yaptide/converter/pull/222?shareId=8201d35a-a2bd-4678-a40d-9f1a4d441bfe).