### PR TITLE
Update scoring names to be distinct for FLUKA

### DIFF
--- a/converter/fluka/cards/scoring_card.py
+++ b/converter/fluka/cards/scoring_card.py
@@ -55,6 +55,12 @@ def handle_usrbin_scoring(detector: _DetectorType, quantity: Quantity, output_un
 
     output_unit_in_fluka_convention = str(output_unit * -1)
 
+    # Make sure that name is processed only once
+    if not quantity.name_processed:
+        # Make each scoring distinct by adding output_unit to the name of scoring
+        quantity.name += f'_{output_unit}'
+        quantity.name_processed = True
+
     output.extend(parse_detector(detector, quantity, quantity_to_score, output_unit_in_fluka_convention))
 
     counter.usrbin_counter += 1
@@ -70,8 +76,7 @@ def handle_usrbin_scoring(detector: _DetectorType, quantity: Quantity, output_un
 def parse_detector(detector, quantity, quantity_to_score, output_unit_in_fluka_convention) -> list[Card]:
     """Creates USRBIN card"""
     if isinstance(detector, CylinderDetector):
-        return _parse_cylinder_detector(detector, quantity, quantity_to_score,
-                                        output_unit_in_fluka_convention)
+        return _parse_cylinder_detector(detector, quantity, quantity_to_score, output_unit_in_fluka_convention)
     return _parse_mesh_detector(detector, quantity, quantity_to_score, output_unit_in_fluka_convention)
 
 
@@ -167,7 +172,6 @@ class ScoringsCard:
 
         # temporary default for no symmetry
         result: list[str] = []
-
         default_output_unit = 21
         counter = ScoringCardIndexCounter()
         for scoring in self.data:

--- a/converter/fluka/cards/scoring_card.py
+++ b/converter/fluka/cards/scoring_card.py
@@ -55,11 +55,8 @@ def handle_usrbin_scoring(detector: _DetectorType, quantity: Quantity, output_un
 
     output_unit_in_fluka_convention = str(output_unit * -1)
 
-    # Make sure that name is processed only once
-    if not quantity.name_processed:
-        # Make each scoring distinct by adding output_unit to the name of scoring
-        quantity.name += f'_{output_unit}'
-        quantity.name_processed = True
+    # save output_unit to quantity object for later unique name generation
+    quantity.output_unit = output_unit
 
     output.extend(parse_detector(detector, quantity, quantity_to_score, output_unit_in_fluka_convention))
 
@@ -87,7 +84,7 @@ def _parse_mesh_detector(detector: MeshDetector, quantity: Quantity, quantity_to
     first_card.what = [
         '10.0', quantity_to_score, output_unit_in_fluka_convention, detector.x_max, detector.y_max, detector.z_max
     ]
-    first_card.sdum = short_name(quantity.name)
+    first_card.sdum = short_name(quantity.name_string())
 
     second_card = Card(codewd='USRBIN')
     second_card.what = [
@@ -110,7 +107,7 @@ def _parse_cylinder_detector(detector: CylinderDetector, quantity: Quantity, qua
     first_card.what = [
         '11.0', quantity_to_score, output_unit_in_fluka_convention, detector.r_max, detector.y, detector.z_max
     ]
-    first_card.sdum = short_name(quantity.name)
+    first_card.sdum = short_name(quantity.name_string())
 
     second_card = Card(codewd='USRBIN')
     second_card.what = [

--- a/converter/fluka/helper_parsers/scoring_parser.py
+++ b/converter/fluka/helper_parsers/scoring_parser.py
@@ -40,13 +40,13 @@ class Quantity:
     def name_string(self) -> str:
         """Generate unique name for scoring based on its name and output_unit"""
         # Create a consistent hash based on the name and output_unit
-        generated_hash = self.generate_custom_hash(f'{self.name}_{self.output_unit}', 5)
+        generated_hash = Quantity.generate_custom_hash(f'{self.name}_{self.output_unit}', 5)
 
         # Generate the string in the desired format
         return f'{self.name[:4]}_{generated_hash}'
 
     @staticmethod
-    def generate_custom_hash(self, input_string, length=10):
+    def generate_custom_hash(input_string, length=10):
         """Generate custom hash with specific length based on input string"""
         # Generate a SHA-256 hash
         hash_object = hashlib.sha256(input_string.encode())

--- a/converter/fluka/helper_parsers/scoring_parser.py
+++ b/converter/fluka/helper_parsers/scoring_parser.py
@@ -30,6 +30,7 @@ class Quantity:
     """Class representing Quantity"""
 
     name: str
+    name_processed = False
     scoring_filter: Optional[Union[CustomFilter, ParticleFilter]]
     modifiers: list[any]  # unused
     keyword: str = 'DOSE'

--- a/converter/fluka/helper_parsers/scoring_parser.py
+++ b/converter/fluka/helper_parsers/scoring_parser.py
@@ -154,13 +154,15 @@ def parse_detector(detector_dict: dict) -> Optional[Union[MeshDetector, Cylinder
 
 
 def generate_custom_hash(input_string, length=10):
-    """Generate custom hash with specific length based on input string"""
+    """Generate custom hash with specific length consisting of only 0-9, a-z and A-Z characters"""
     # Generate a SHA-256 hash
     hash_object = hashlib.sha256(input_string.encode())
     # Get the binary digest
     binary_hash = hash_object.digest()
-    # Encode it in base64 and replace non-alphanumeric characters
-    base64_hash = base64.urlsafe_b64encode(binary_hash).decode('utf-8')
+    # Encode it in standard base64
+    base64_hash = base64.b64encode(binary_hash).decode('utf-8')
+    # Replace '+' and '/' with alphanumeric characters (e.g., 'a' and 'b')
+    base64_hash = base64_hash.replace('+', 'a').replace('/', 'b')
     # Remove padding '=' and truncate to the desired length
     custom_hash = base64_hash.replace('=', '')[:length]
     return custom_hash

--- a/converter/fluka/helper_parsers/scoring_parser.py
+++ b/converter/fluka/helper_parsers/scoring_parser.py
@@ -40,23 +40,10 @@ class Quantity:
     def name_string(self) -> str:
         """Generate unique name for scoring based on its name and output_unit"""
         # Create a consistent hash based on the name and output_unit
-        generated_hash = Quantity.generate_custom_hash(f'{self.name}_{self.output_unit}', 5)
+        generated_hash = generate_custom_hash(f'{self.name}_{self.output_unit}', 5)
 
         # Generate the string in the desired format
         return f'{self.name[:4]}_{generated_hash}'
-
-    @staticmethod
-    def generate_custom_hash(input_string, length=10):
-        """Generate custom hash with specific length based on input string"""
-        # Generate a SHA-256 hash
-        hash_object = hashlib.sha256(input_string.encode())
-        # Get the binary digest
-        binary_hash = hash_object.digest()
-        # Encode it in base64 and replace non-alphanumeric characters
-        base64_hash = base64.urlsafe_b64encode(binary_hash).decode('utf-8')
-        # Remove padding '=' and truncate to the desired length
-        custom_hash = base64_hash.replace('=', '')[:length]
-        return custom_hash
 
 
 @dataclass
@@ -164,3 +151,16 @@ def parse_detector(detector_dict: dict) -> Optional[Union[MeshDetector, Cylinder
         return parse_cylinder_detector(detector_dict)
 
     return None
+
+
+def generate_custom_hash(input_string, length=10):
+    """Generate custom hash with specific length based on input string"""
+    # Generate a SHA-256 hash
+    hash_object = hashlib.sha256(input_string.encode())
+    # Get the binary digest
+    binary_hash = hash_object.digest()
+    # Encode it in base64 and replace non-alphanumeric characters
+    base64_hash = base64.urlsafe_b64encode(binary_hash).decode('utf-8')
+    # Remove padding '=' and truncate to the desired length
+    custom_hash = base64_hash.replace('=', '')[:length]
+    return custom_hash

--- a/converter/fluka/helper_parsers/scoring_parser.py
+++ b/converter/fluka/helper_parsers/scoring_parser.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional, Union
-import hashlib, base64
+import hashlib
+import base64
 
 from converter.fluka.helper_parsers.detector_parser import MeshDetector, parse_mesh_detector, CylinderDetector, \
     parse_cylinder_detector
@@ -37,14 +38,16 @@ class Quantity:
     keyword: str = 'DOSE'
 
     def name_string(self) -> str:
-
+        """Generate unique name for scoring based on its name and output_unit"""
         # Create a consistent hash based on the name and output_unit
         generated_hash = self.generate_custom_hash(f'{self.name}_{self.output_unit}', 5)
 
         # Generate the string in the desired format
         return f'{self.name[:4]}_{generated_hash}'
 
+    @staticmethod
     def generate_custom_hash(self, input_string, length=10):
+        """Generate custom hash with specific length based on input string"""
         # Generate a SHA-256 hash
         hash_object = hashlib.sha256(input_string.encode())
         # Get the binary digest

--- a/tests/fluka/expected_fluka_output/fl_sim.py
+++ b/tests/fluka/expected_fluka_output/fl_sim.py
@@ -72,7 +72,7 @@ ASSIGNMA         AIR   region3
 ASSIGNMA       WATER     world
 ASSIGNMA    BLCKHOLE  boundary
 * generated scoring cards
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Flue_16255
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Flue_TzG3O
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 * random number generator settings

--- a/tests/fluka/expected_fluka_output/fl_sim.py
+++ b/tests/fluka/expected_fluka_output/fl_sim.py
@@ -72,7 +72,7 @@ ASSIGNMA         AIR   region3
 ASSIGNMA       WATER     world
 ASSIGNMA    BLCKHOLE  boundary
 * generated scoring cards
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence_21
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Flue_16255
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 * random number generator settings

--- a/tests/fluka/expected_fluka_output/fl_sim.py
+++ b/tests/fluka/expected_fluka_output/fl_sim.py
@@ -72,7 +72,7 @@ ASSIGNMA         AIR   region3
 ASSIGNMA       WATER     world
 ASSIGNMA    BLCKHOLE  boundary
 * generated scoring cards
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence_21
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 * random number generator settings

--- a/tests/fluka/test_scoring_card.py
+++ b/tests/fluka/test_scoring_card.py
@@ -47,7 +47,7 @@ def detectors_json_4(project4_fluka_json: dict) -> dict:
 def expected_card() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence_21
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 """
@@ -59,7 +59,7 @@ AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 def expected_scores() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence_21
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 """
@@ -71,10 +71,10 @@ AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 def expected_scores_2() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence_21
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
-USRBIN          10.0      DOSE     -22.0      12.5      25.0      37.5MyDose
+USRBIN          10.0      DOSE     -22.0      12.5      25.0      37.5MyDose_22
 USRBIN           7.5      15.0      22.5      10.0     100.0     150.0&
 AUXSCORE      USRBIN   NEUTRON                 2.0       2.0       1.0
 """
@@ -86,7 +86,7 @@ AUXSCORE      USRBIN   NEUTRON                 2.0       2.0       1.0
 def expected_scores_cylinder() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          11.0      DOSE     -21.0       3.0       0.0      21.0Dose1
+USRBIN          11.0      DOSE     -21.0       3.0       0.0      21.0Dose1_21
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 """
 
@@ -97,36 +97,36 @@ USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 def expected_scores_4() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Total
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Total_21
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Proton
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Proton_21
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN    PROTON                 2.0       2.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He3
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He3_21
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN  3-HELIUM                 3.0       3.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_C_Cus
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_C_Cus_21
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN-1200600.0                 4.0       4.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He_Cus
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He_Cus_21
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -400200.0                 5.0       5.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_B_Cus
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_B_Cus_21
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -900400.0                 6.0       6.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_Total
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_Total_22
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
-USRBIN          11.0    PROTON     -22.0       2.5       0.0      21.0F_Proton
+USRBIN          11.0    PROTON     -22.0       2.5       0.0      21.0F_Proton_22
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
-USRBIN          11.0  3-HELIUM     -22.0       2.5       0.0      21.0F_He3
+USRBIN          11.0  3-HELIUM     -22.0       2.5       0.0      21.0F_He3_22
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_C_Cus
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_C_Cus_22
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN-1200600.0                10.0      10.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_He_Cus
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_He_Cus_22
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -400200.0                11.0      11.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_B_Cus
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_B_Cus_22
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -900400.0                12.0      12.0       1.0
 """
@@ -160,5 +160,7 @@ def test_scoring_dose_and_fluence_with_two_detectors(detectors_json_4: dict, sco
                                                      expected_scores_4: str) -> None:
     scorings = parse_scorings(detectors_json_4, scorings_json_4)
     scorings_card = ScoringsCard(scorings)
+    print(expected_scores_4)
+    print(scorings_card)
 
     assert str(scorings_card) == expected_scores_4

--- a/tests/fluka/test_scoring_card.py
+++ b/tests/fluka/test_scoring_card.py
@@ -59,7 +59,7 @@ AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 def expected_scores() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence_21
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Flue_16255
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 """
@@ -71,10 +71,10 @@ AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 def expected_scores_2() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Fluence_21
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Flue_16255
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
-USRBIN          10.0      DOSE     -22.0      12.5      25.0      37.5MyDose_22
+USRBIN          10.0      DOSE     -22.0      12.5      25.0      37.5MyDo_33280
 USRBIN           7.5      15.0      22.5      10.0     100.0     150.0&
 AUXSCORE      USRBIN   NEUTRON                 2.0       2.0       1.0
 """
@@ -86,7 +86,7 @@ AUXSCORE      USRBIN   NEUTRON                 2.0       2.0       1.0
 def expected_scores_cylinder() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          11.0      DOSE     -21.0       3.0       0.0      21.0Dose1_21
+USRBIN          11.0      DOSE     -21.0       3.0       0.0      21.0Dose_30008
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 """
 
@@ -97,36 +97,36 @@ USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 def expected_scores_4() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Total_21
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_To_48870
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Proton_21
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Pr_63880
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN    PROTON                 2.0       2.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He3_21
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He_77998
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN  3-HELIUM                 3.0       3.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_C_Cus_21
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_C__70056
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN-1200600.0                 4.0       4.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He_Cus_21
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He_69410
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -400200.0                 5.0       5.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_B_Cus_21
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_B__88407
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -900400.0                 6.0       6.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_Total_22
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_To_97669
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
-USRBIN          11.0    PROTON     -22.0       2.5       0.0      21.0F_Proton_22
+USRBIN          11.0    PROTON     -22.0       2.5       0.0      21.0F_Pr_87248
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
-USRBIN          11.0  3-HELIUM     -22.0       2.5       0.0      21.0F_He3_22
+USRBIN          11.0  3-HELIUM     -22.0       2.5       0.0      21.0F_He_66868
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_C_Cus_22
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_C__72199
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN-1200600.0                10.0      10.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_He_Cus_22
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_He_84923
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -400200.0                11.0      11.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_B_Cus_22
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_B__95162
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -900400.0                12.0      12.0       1.0
 """
@@ -160,7 +160,5 @@ def test_scoring_dose_and_fluence_with_two_detectors(detectors_json_4: dict, sco
                                                      expected_scores_4: str) -> None:
     scorings = parse_scorings(detectors_json_4, scorings_json_4)
     scorings_card = ScoringsCard(scorings)
-    print(expected_scores_4)
-    print(scorings_card)
 
     assert str(scorings_card) == expected_scores_4

--- a/tests/fluka/test_scoring_card.py
+++ b/tests/fluka/test_scoring_card.py
@@ -59,7 +59,7 @@ AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 def expected_scores() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Flue_16255
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Flue_TzG3O
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 """
@@ -71,10 +71,10 @@ AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
 def expected_scores_2() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Flue_16255
+USRBIN          10.0  ALL-PART     -21.0      0.05       5.0       6.0Flue_TzG3O
 USRBIN         -0.05      -5.0      -6.0       1.0     100.0     120.0&
 AUXSCORE      USRBIN -100100.0                 1.0       1.0       1.0
-USRBIN          10.0      DOSE     -22.0      12.5      25.0      37.5MyDo_33280
+USRBIN          10.0      DOSE     -22.0      12.5      25.0      37.5MyDo_dX4W2
 USRBIN           7.5      15.0      22.5      10.0     100.0     150.0&
 AUXSCORE      USRBIN   NEUTRON                 2.0       2.0       1.0
 """
@@ -86,7 +86,7 @@ AUXSCORE      USRBIN   NEUTRON                 2.0       2.0       1.0
 def expected_scores_cylinder() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          11.0      DOSE     -21.0       3.0       0.0      21.0Dose_30008
+USRBIN          11.0      DOSE     -21.0       3.0       0.0      21.0Dose_Tt536
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 """
 
@@ -97,36 +97,36 @@ USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 def expected_scores_4() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_To_48870
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_To_-l6m6
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Pr_63880
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Pr_EWZdl
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN    PROTON                 2.0       2.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He_77998
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He_q3AVx
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN  3-HELIUM                 3.0       3.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_C__70056
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_C__8Y1Bp
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN-1200600.0                 4.0       4.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He_69410
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_He_oeZGk
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -400200.0                 5.0       5.0       1.0
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_B__88407
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_B__HBQJv
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -900400.0                 6.0       6.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_To_97669
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_To_SNVdq
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
-USRBIN          11.0    PROTON     -22.0       2.5       0.0      21.0F_Pr_87248
+USRBIN          11.0    PROTON     -22.0       2.5       0.0      21.0F_Pr_7CgH1
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
-USRBIN          11.0  3-HELIUM     -22.0       2.5       0.0      21.0F_He_66868
+USRBIN          11.0  3-HELIUM     -22.0       2.5       0.0      21.0F_He_KCn1N
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_C__72199
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_C__w6biy
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN-1200600.0                10.0      10.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_He_84923
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_He_WQwN-
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -400200.0                11.0      11.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_B__95162
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_B__WYZoZ
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -900400.0                12.0      12.0       1.0
 """

--- a/tests/fluka/test_scoring_card.py
+++ b/tests/fluka/test_scoring_card.py
@@ -97,7 +97,7 @@ USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 def expected_scores_4() -> str:
     """Returns expected Fluka scoring card sets"""
     lines = """
-USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_To_-l6m6
+USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_To_al6m6
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
 USRBIN          10.0      DOSE     -21.0       2.5       2.5      21.0D_Pr_EWZdl
 USRBIN          -2.5      -2.5       3.0       1.0       1.0     100.0&
@@ -123,7 +123,7 @@ USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_C__w6biy
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN-1200600.0                10.0      10.0       1.0
-USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_He_WQwN-
+USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_He_WQwNa
 USRBIN           0.0       0.0       3.0       1.0       1.0     100.0&
 AUXSCORE      USRBIN -400200.0                11.0      11.0       1.0
 USRBIN          11.0  ALL-PART     -22.0       2.5       0.0      21.0F_B__WYZoZ


### PR DESCRIPTION
This pull request includes several changes to the `converter/fluka` module, focusing on enhancing the handling and generation of unique names for scoring quantities. The main improvements include adding a new method to generate unique names, updating the `Quantity` class, and modifying the relevant test cases to reflect these changes.

Enhancements to unique name generation:

* [`converter/fluka/helper_parsers/scoring_parser.py`](diffhunk://#diff-829cce531de82a2e26d8b873e9a04a16191f345c6010d3a85c8be24747f6f410R35-R47): Added the `name_string` method to the `Quantity` class to generate unique names based on the quantity's name and output unit. This method uses a custom hash function to ensure uniqueness.
* [`converter/fluka/helper_parsers/scoring_parser.py`](diffhunk://#diff-829cce531de82a2e26d8b873e9a04a16191f345c6010d3a85c8be24747f6f410R154-R168): Implemented the `generate_custom_hash` function to create consistent and unique hashes for the `name_string` method.

Updates to scoring card parsing:

* [`converter/fluka/cards/scoring_card.py`](diffhunk://#diff-a90993e26aac5cb254d20593ae0a2bf93f795aa7afaa95537d6e4cf57c3dfe99R58-R60): Modified the `handle_usrbin_scoring`, `_parse_mesh_detector`, and `_parse_cylinder_detector` functions to use the new `name_string` method for generating unique names. [[1]](diffhunk://#diff-a90993e26aac5cb254d20593ae0a2bf93f795aa7afaa95537d6e4cf57c3dfe99R58-R60) [[2]](diffhunk://#diff-a90993e26aac5cb254d20593ae0a2bf93f795aa7afaa95537d6e4cf57c3dfe99L85-R87) [[3]](diffhunk://#diff-a90993e26aac5cb254d20593ae0a2bf93f795aa7afaa95537d6e4cf57c3dfe99L108-R110)

Test case modifications:

* `tests/fluka/test_scoring_card.py` and `tests/fluka/expected_fluka_output/fl_sim.py`: Updated the expected output in test cases to reflect the new unique naming convention for scoring quantities. [[1]](diffhunk://#diff-e4a90594520426c72b63e060cdc3025773531dc4e94ad3e1b187656e11613bc0L50-R50) [[2]](diffhunk://#diff-e4a90594520426c72b63e060cdc3025773531dc4e94ad3e1b187656e11613bc0L62-R62) [[3]](diffhunk://#diff-e4a90594520426c72b63e060cdc3025773531dc4e94ad3e1b187656e11613bc0L74-R77) [[4]](diffhunk://#diff-e4a90594520426c72b63e060cdc3025773531dc4e94ad3e1b187656e11613bc0L89-R89) [[5]](diffhunk://#diff-55c7cbe31cc8cd60985c68243c851745e105aeaf93ffce52fe7a7d7043c0d0d2L75-R75)