### PR TITLE
Use toSerialized method instead of toJSON in generators

### DIFF
--- a/tests/fluka/project.json
+++ b/tests/fluka/project.json
@@ -2,7 +2,7 @@
 	"metadata": {
 		"version": "0.11",
 		"type": "Editor",
-		"generator": "YaptideEditor.toJSON"
+		"generator": "YaptideEditor.toSerialized"
 	},
 	"project": {
 		"title": "new.json",
@@ -48,7 +48,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "FigureManager.toJSON"
+			"generator": "FigureManager.toSerialized"
 		},
 		"figures": [
 			{
@@ -142,7 +142,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "ZoneManager.toJSON"
+			"generator": "ZoneManager.toSerialized"
 		},
 		"zones": [
 			{
@@ -274,7 +274,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "DetectorManager.toJSON"
+			"generator": "DetectorManager.toSerialized"
 		},
 		"detectors": [
 			{
@@ -305,7 +305,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "SpecialComponentManager.toJSON"
+			"generator": "SpecialComponentManager.toSerialized"
 		}
 	},
 	"materialManager": {
@@ -337,7 +337,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "MaterialManager.toJSON"
+			"generator": "MaterialManager.toSerialized"
 		}
 	},
 	"scoringManager": {
@@ -384,7 +384,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "ScoringManager.toJSON"
+			"generator": "ScoringManager.toSerialized"
 		}
 	},
 	"beam": {

--- a/tests/fluka/project2.json
+++ b/tests/fluka/project2.json
@@ -2,7 +2,7 @@
 	"metadata": {
 		"version": "0.11",
 		"type": "Editor",
-		"generator": "YaptideEditor.toJSON"
+		"generator": "YaptideEditor.toSerialized"
 	},
 	"project": {
 		"title": "new.json",
@@ -48,7 +48,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "FigureManager.toJSON"
+			"generator": "FigureManager.toSerialized"
 		},
 		"figures": [
 			{
@@ -142,7 +142,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "ZoneManager.toJSON"
+			"generator": "ZoneManager.toSerialized"
 		},
 		"zones": [
 			{
@@ -274,7 +274,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "DetectorManager.toJSON"
+			"generator": "DetectorManager.toSerialized"
 		},
 		"detectors": [
 			{
@@ -346,7 +346,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "SpecialComponentManager.toJSON"
+			"generator": "SpecialComponentManager.toSerialized"
 		}
 	},
 	"materialManager": {
@@ -378,7 +378,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "MaterialManager.toJSON"
+			"generator": "MaterialManager.toSerialized"
 		}
 	},
 	"scoringManager": {
@@ -469,7 +469,7 @@
 		"metadata": {
 			"version": "0.11",
 			"type": "Manager",
-			"generator": "ScoringManager.toJSON"
+			"generator": "ScoringManager.toSerialized"
 		}
 	},
 	"beam": {

--- a/tests/fluka/project3.json
+++ b/tests/fluka/project3.json
@@ -2,7 +2,7 @@
 	"metadata": {
 		"version": "0.12",
 		"type": "Editor",
-		"generator": "YaptideEditor.toJSON"
+		"generator": "YaptideEditor.toSerialized"
 	},
 	"project": {
 		"title": "simple_example_9",
@@ -48,7 +48,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "FigureManager.toJSON"
+			"generator": "FigureManager.toSerialized"
 		},
 		"figures": [
 			{
@@ -76,7 +76,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "ZoneManager.toJSON"
+			"generator": "ZoneManager.toSerialized"
 		},
 		"zones": [
 			{
@@ -122,7 +122,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "DetectorManager.toJSON"
+			"generator": "DetectorManager.toSerialized"
 		},
 		"detectors": [
 			{
@@ -152,7 +152,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "SpecialComponentManager.toJSON"
+			"generator": "SpecialComponentManager.toSerialized"
 		}
 	},
 	"materialManager": {
@@ -176,7 +176,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "MaterialManager.toJSON"
+			"generator": "MaterialManager.toSerialized"
 		}
 	},
 	"scoringManager": {
@@ -287,7 +287,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "ScoringManager.toJSON"
+			"generator": "ScoringManager.toSerialized"
 		}
 	},
 	"beam": {

--- a/tests/fluka/project4.json
+++ b/tests/fluka/project4.json
@@ -2,7 +2,7 @@
 	"metadata": {
 		"version": "0.12",
 		"type": "Editor",
-		"generator": "YaptideEditor.toJSON"
+		"generator": "YaptideEditor.toSerialized"
 	},
 	"project": {
 		"title": "depth_profile_carbon_beam_7",
@@ -48,7 +48,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "FigureManager.toJSON"
+			"generator": "FigureManager.toSerialized"
 		},
 		"figures": [
 			{
@@ -76,7 +76,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "ZoneManager.toJSON"
+			"generator": "ZoneManager.toSerialized"
 		},
 		"zones": [
 			{
@@ -122,7 +122,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "DetectorManager.toJSON"
+			"generator": "DetectorManager.toSerialized"
 		},
 		"detectors": [
 			{
@@ -172,7 +172,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "SpecialComponentManager.toJSON"
+			"generator": "SpecialComponentManager.toSerialized"
 		}
 	},
 	"materialManager": {
@@ -204,7 +204,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "MaterialManager.toJSON"
+			"generator": "MaterialManager.toSerialized"
 		}
 	},
 	"scoringManager": {
@@ -464,7 +464,7 @@
 		"metadata": {
 			"version": "0.12",
 			"type": "Manager",
-			"generator": "ScoringManager.toJSON"
+			"generator": "ScoringManager.toSerialized"
 		}
 	},
 	"beam": {

--- a/tests/shieldhit/resources/expected_shieldhit_output/geo.dat
+++ b/tests/shieldhit/resources/expected_shieldhit_output/geo.dat
@@ -1,19 +1,22 @@
 
     0    0          Proton pencil beam in water
 * cylinder Water_phantom_cylinder
-* bottom center (+0.0, +0.0, +0.0), spanning vector (+0.0, +0.0, +20.0),
+* bottom center (+0.0, +0.0, +0.0), top center (+0.0, +0.0, +20.0),
+* spanning vector (+0.0, +0.0, +20.0),
 * radius +5.0, height +20.0 cm
 * rotation angles: 0*, 0*, 0*
   RCC    1       0.0       0.0       0.0       0.0       0.0      20.0
                  5.0
 * cylinder Vacuum_cylinder
-* bottom center (+0.0, +0.0, -0.5), spanning vector (+0.0, +0.0, +22.0),
+* bottom center (+0.0, +0.0, -0.5), top center (+0.0, +0.0, +21.5),
+* spanning vector (+0.0, +0.0, +22.0),
 * radius +5.5, height +22.0 cm
 * rotation angles: 0*, 0*, 0*
   RCC    2       0.0       0.0      -0.5       0.0       0.0      22.0
                  5.5
 * cylinder World Zone
-* bottom center (+0.0, +0.0, -1.5), spanning vector (+0.0, +0.0, +24.0),
+* bottom center (+0.0, +0.0, -1.5), top center (+0.0, +0.0, +22.5),
+* spanning vector (+0.0, +0.0, +24.0),
 * radius +6.0, height +24.0 cm
 * rotation angles: 0*, 0*, 0*
   RCC    3       0.0       0.0      -1.5       0.0       0.0      24.0
@@ -21,7 +24,7 @@
   END
   001          +1
   002          +2     -1
-  003          +3     -1     -2
+  003          -2     +3     -1
   END
     1    2    3
     1 1000    0

--- a/tests/shieldhit/resources/expected_shieldhit_output_with_sobp_dat/geo.dat
+++ b/tests/shieldhit/resources/expected_shieldhit_output_with_sobp_dat/geo.dat
@@ -1,19 +1,22 @@
 
     0    0          Proton pencil beam in water
 * cylinder Water_phantom_cylinder
-* bottom center (+0.0, +0.0, +0.0), spanning vector (+0.0, +0.0, +20.0),
+* bottom center (+0.0, +0.0, +0.0), top center (+0.0, +0.0, +20.0),
+* spanning vector (+0.0, +0.0, +20.0),
 * radius +5.0, height +20.0 cm
 * rotation angles: 0*, 0*, 0*
   RCC    1       0.0       0.0       0.0       0.0       0.0      20.0
                  5.0
 * cylinder Vacuum_cylinder
-* bottom center (+0.0, +0.0, -0.5), spanning vector (+0.0, +0.0, +22.0),
+* bottom center (+0.0, +0.0, -0.5), top center (+0.0, +0.0, +21.5),
+* spanning vector (+0.0, +0.0, +22.0),
 * radius +5.5, height +22.0 cm
 * rotation angles: 0*, 0*, 0*
   RCC    2       0.0       0.0      -0.5       0.0       0.0      22.0
                  5.5
 * cylinder World Zone
-* bottom center (+0.0, +0.0, -1.5), spanning vector (+0.0, +0.0, +24.0),
+* bottom center (+0.0, +0.0, -1.5), top center (+0.0, +0.0, +22.5),
+* spanning vector (+0.0, +0.0, +24.0),
 * radius +6.0, height +24.0 cm
 * rotation angles: 0*, 0*, 0*
   RCC    3       0.0       0.0      -1.5       0.0       0.0      24.0
@@ -21,7 +24,7 @@
   END
   001          +1
   002          +2     -1
-  003          +3     -1     -2
+  003          -2     +3     -1
   END
     1    2    3
     1 1000    0

--- a/tests/shieldhit/resources/project.json
+++ b/tests/shieldhit/resources/project.json
@@ -2,7 +2,7 @@
     "metadata": {
         "version": "0.10",
         "type": "Editor",
-        "generator": "YaptideEditor.toJSON"
+        "generator": "YaptideEditor.toSerialized"
     },
     "project": {
         "title": "Proton pencil beam in water",
@@ -79,7 +79,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "FigureManager.toJSON"
+            "generator": "FigureManager.toSerialized"
         },
         "figures": [
             {
@@ -125,7 +125,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "ZoneManager.toJSON"
+            "generator": "ZoneManager.toSerialized"
         },
         "zones": [
             {
@@ -199,7 +199,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "DetectorManager.toJSON"
+            "generator": "DetectorManager.toSerialized"
         },
         "detectors": [
             {
@@ -288,7 +288,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "SpecialComponentManager.toJSON"
+            "generator": "SpecialComponentManager.toSerialized"
         }
     },
     "materialManager": {
@@ -333,7 +333,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "MaterialManager.toJSON"
+            "generator": "MaterialManager.toSerialized"
         }
     },
     "scoringManager": {
@@ -634,7 +634,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "ScoringManager.toJSON"
+            "generator": "ScoringManager.toSerialized"
         }
     },
     "beam": {

--- a/tests/shieldhit/resources/project_with_sobp.json
+++ b/tests/shieldhit/resources/project_with_sobp.json
@@ -2,7 +2,7 @@
     "metadata": {
         "version": "0.10",
         "type": "Editor",
-        "generator": "YaptideEditor.toJSON"
+        "generator": "YaptideEditor.toSerialized"
     },
     "project": {
         "title": "Proton pencil beam in water",
@@ -79,7 +79,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "FigureManager.toJSON"
+            "generator": "FigureManager.toSerialized"
         },
         "figures": [
             {
@@ -125,7 +125,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "ZoneManager.toJSON"
+            "generator": "ZoneManager.toSerialized"
         },
         "zones": [
             {
@@ -199,7 +199,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "DetectorManager.toJSON"
+            "generator": "DetectorManager.toSerialized"
         },
         "detectors": [
             {
@@ -288,7 +288,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "SpecialComponentManager.toJSON"
+            "generator": "SpecialComponentManager.toSerialized"
         }
     },
     "materialManager": {
@@ -333,7 +333,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "MaterialManager.toJSON"
+            "generator": "MaterialManager.toSerialized"
         }
     },
     "scoringManager": {
@@ -624,7 +624,7 @@
         "metadata": {
             "version": "0.10",
             "type": "Manager",
-            "generator": "ScoringManager.toJSON"
+            "generator": "ScoringManager.toSerialized"
         }
     },
     "beam": {


### PR DESCRIPTION
This pull request updates the `generator` field across multiple JSON configuration files and modifies the geometry description in two `.dat` files. The main changes involve standardizing the serialization method and improving the clarity of geometry definitions.

### Updates to JSON Configuration Files:
* Replaced `toJSON` with `toSerialized` in the `generator` field for various managers and editors across multiple JSON files, including `project.json`, `project2.json`, `project3.json`, `project4.json`, and `project_with_sobp.json`. This change ensures consistency in the serialization method used. [[1]](diffhunk://#diff-8bebaa35c0fd1b7a217b540f06ab53ad4438ac0c252f1fbe3210231da48c0c4fL5-R5) [[2]](diffhunk://#diff-e0d8763be911d1d06eb65ea45c944033e097eae6deb17b51ab6c2c6349e3177cL5-R5) [[3]](diffhunk://#diff-cc9a695e992ba52946151afd8c44a31dc805dc4982a248f8e3944dfccb9edb0cL5-R5) [[4]](diffhunk://#diff-fdcbaaa1baf1b075f2fe8e04e4b235b280cfcd651f459687a2abef46cce3bf9cL5-R5) [[5]](diffhunk://#diff-3174ecb91c25fdc495176532a676accf503860ee2b33cbaff5b29a0b833be3ebL5-R5) [[6]](diffhunk://#diff-3acd6f2451db487c1ce6781bb3d3c09ed13dd4cb1c9b04894aa56b21705f4d49L5-R5)

### Improvements to Geometry Descriptions:
* Updated `.dat` files to include `top center` coordinates alongside `bottom center` and `spanning vector` for cylinder definitions, enhancing clarity in geometry descriptions. Affected files: `geo.dat` and `geo_with_sobp.dat`. [[1]](diffhunk://#diff-4716f5bbc84a858f0de29a4518d1e55a002306cfc60e3aefdcb925dec0e9c351L4-R27) [[2]](diffhunk://#diff-4716f5bbc84a858f0de29a4518d1e55a002306cfc60e3aefdcb925dec0e9c351L4-R27)
* Adjusted the order of zone definitions in the `.dat` files to correct logical inconsistencies. [[1]](diffhunk://#diff-4716f5bbc84a858f0de29a4518d1e55a002306cfc60e3aefdcb925dec0e9c351L4-R27) [[2]](diffhunk://#diff-4716f5bbc84a858f0de29a4518d1e55a002306cfc60e3aefdcb925dec0e9c351L4-R27)