### PR TITLE
Add missing info.json to Geant4 converter

### DIFF
--- a/converter/geant4/parser.py
+++ b/converter/geant4/parser.py
@@ -35,8 +35,12 @@ class Geant4Parser(Parser):
 
     def get_configs_json(self) -> dict:
         """Return dictionary from gdml content"""
-        return {"geometry.gdml": self._gdml_content,
-                "run.mac": self._macro_content}
+        configs_json = super().get_configs_json()
+        configs_json.update({
+            "geometry.gdml": self._gdml_content,
+            "run.mac": self._macro_content,
+        })
+        return configs_json
 
     @staticmethod
     def _prettify_xml(root: ET.Element) -> str:


### PR DESCRIPTION
The converter misses call to superclass in `get_configs_json()` thus omitting `info.json` file. This PR adds the file.